### PR TITLE
Adding clean for deployment branch

### DIFF
--- a/.github/workflows/deployment-clean.yml
+++ b/.github/workflows/deployment-clean.yml
@@ -29,13 +29,17 @@ jobs:
       - name: Ensure deployment branch exists locally
         run: |
           if git ls-remote --exit-code --heads origin deployment; then
-            git fetch origin deployment:deployment
+            git fetch origin deployment
+            git checkout deployment
+            git reset --hard origin/deployment
           else
             git checkout --orphan deployment
             git rm -rf .
             git commit --allow-empty -m "Initialize deployment branch"
             git push origin deployment
-            git fetch origin deployment:deployment
+            git fetch origin deployment
+            git checkout deployment
+            git reset --hard origin/deployment
           fi
 
       - name: Checkout deployment branch


### PR DESCRIPTION
this should create a deployment branch where code deployed to the web server resides. This will remove tests and test data or other resources, like uncompiled translations, form the deployment to keep it as small as necessary.